### PR TITLE
Added missing import of new auth email pod

### DIFF
--- a/Auth/README.md
+++ b/Auth/README.md
@@ -33,6 +33,7 @@ Add the following to your `Podfile`:
 ```ruby
 pod 'FirebaseUI/Auth'
 
+pod 'FirebaseUI/Email'
 pod 'FirebaseUI/Google'
 pod 'FirebaseUI/Facebook'
 pod 'FirebaseUI/Twitter'


### PR DESCRIPTION
The import of the new FirebaseUI/Email pod was missing for the sample code to work properly.

